### PR TITLE
add options.root

### DIFF
--- a/lib/save.js
+++ b/lib/save.js
@@ -6,6 +6,7 @@ var timestamp = require('time-stamp')
 var assert = require('assert')
 var xtend = require('xtend')
 var path = require('path')
+var mkdirp = require("mkdirp")
 
 var libGet = require('./get')
 var utilText = require('../utils/text')
@@ -28,7 +29,14 @@ function save (url, opts) {
     if (err) throw err.message
 
     var pageContent = getPageContent(options.template, page)
-    var dirOutput = path.join(options.output, page.basename)
+    if (options.root) {
+      if (!options.output) {
+        throw new Error("options.root requires options.output")
+      }
+      var dirOutput = path.join(options.output)
+    } else {
+      var dirOutput = path.join(options.output, page.basename)
+    }
 
     var outputContent = createHTML({
       head: '<style>' + options.style + '</style>',
@@ -36,13 +44,20 @@ function save (url, opts) {
       body: pageContent
     })
 
-    try {
-      fs.mkdirSync(dirOutput)
-      fs.writeFileSync(path.join(dirOutput, 'index.html'), outputContent)
-      fs.writeFileSync(path.join(dirOutput, 'index.json'), JSON.stringify(page, { }, 2))
-    } catch (err) {
-      throw new Error('page has already been saved')
-    }
+    return new Promise((resolve, reject) => {
+      mkdirp(dirOutput, (err) => {
+        if (err) { console.error(err); return reject(err) }
+        resolve()
+      })
+    }).then(() => {
+      try {
+        fs.writeFileSync(path.join(dirOutput, 'index.html'), outputContent)
+        fs.writeFileSync(path.join(dirOutput, 'index.json'), JSON.stringify(page, { }, 2))
+      } catch (err) {
+        console.error(err)
+        throw new Error('page has already been saved')
+      }
+    })
   })
 }
 

--- a/readme.md
+++ b/readme.md
@@ -53,6 +53,10 @@ Pass a custom filesystem for saving. Expects `mkdirSync`, `writeFileSync`.
 
 The output (parent) directory the page directory will be saved to.
 
+### `options.root`
+
+Specifies that the `options.output` directory will be the root directory, rather than parent. Requires `options.output`.
+
 ### `options.prepend`
 
 Prepend the directory name with a custom [timestamp](https://www.npmjs.com/package/time-stamp). Defaults to `YYMMDD`.


### PR DESCRIPTION
this adds options.root, which combined with options.output will cause the scraped
content to be saved directly to the options.output folder, rather than use
options.output as a parent folder.

the reason i added this is i wanted this control when using dropout as part of my
own scraper

lmk if you want this fixed up in any way!